### PR TITLE
refactor: bundle events

### DIFF
--- a/src/events/debug.ts
+++ b/src/events/debug.ts
@@ -1,6 +1,6 @@
 import { createEvent, CustomClient } from "../util";
 
-export const event = createEvent({
+export const debugEvent = createEvent({
 	name: "debug",
 	on(info) {
 		CustomClient.printToStdout(info);

--- a/src/events/error.ts
+++ b/src/events/error.ts
@@ -1,6 +1,6 @@
 import { createEvent, CustomClient } from "../util";
 
-export const event = createEvent({
+export const errorEvent = createEvent({
 	name: "error",
 	on(error) {
 		CustomClient.printToStderr(error);

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,0 +1,6 @@
+export * from "./debug";
+export * from "./error";
+export * from "./interactionCreate";
+export * from "./invalidated";
+export * from "./ready";
+export * from "./warn";

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,7 +1,7 @@
 import { InteractionType } from "discord.js";
 import { createEvent } from "../util";
 
-export const event = createEvent({
+export const interactionCreateEvent = createEvent({
 	name: "interactionCreate",
 	async on(interaction) {
 		let action: string | undefined;

--- a/src/events/invalidated.ts
+++ b/src/events/invalidated.ts
@@ -1,7 +1,7 @@
 import { exit, nextTick } from "node:process";
 import { CustomClient, createEvent } from "../util";
 
-export const event = createEvent({
+export const invalidatedEvent = createEvent({
 	name: "invalidated",
 	async once() {
 		CustomClient.printToStderr(

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,6 +1,6 @@
 import { Constants, createEvent, loadQuotes } from "../util";
 
-export const event = createEvent({
+export const readyEvent = createEvent({
 	name: "ready",
 	async once(client) {
 		await Promise.all([client.application.fetch(), loadQuotes(this.client)]);

--- a/src/events/warn.ts
+++ b/src/events/warn.ts
@@ -1,6 +1,6 @@
 import { createEvent, CustomClient } from "../util";
 
-export const event = createEvent({
+export const warnEvent = createEvent({
 	name: "warn",
 	on(warn) {
 		CustomClient.printToStderr(warn);

--- a/src/util/loadCommands.ts
+++ b/src/util/loadCommands.ts
@@ -1,17 +1,16 @@
 import { ApplicationCommandType } from "discord.js";
 import type { CommandOptions, CustomClient } from ".";
-import * as commands from "../commands";
 import Command from "./Command";
 
 /**
  * Loads all commands from the commands directory.
  * @param client - The client to load commands into
  */
-export const loadCommands = async (client: CustomClient, clean = false) => {
+export const loadCommands = async (client: CustomClient) => {
 	client.commands.clear();
 	// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
 	for (const command of Object.values(
-		clean ? await import(`./commands/index.js?${Date.now()}`) : commands,
+		await import(`./commands/index.js?${Date.now()}`),
 	) as CommandOptions[])
 		client.commands.set(
 			command.data.find(({ type }) => type === ApplicationCommandType.ChatInput)?.name ??

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,19 +5,23 @@ import { defineConfig, Options } from "tsup";
 if (!("NODE_ENV" in env)) config();
 const options: Options = {
 	clean: true,
-	entry: ["src/index.ts", "src/registerCommands.ts", "src/events/**/*.ts"],
+	entry: [
+		"src/index.ts",
+		"src/registerCommands.ts",
+		"src/commands/index.ts",
+		"src/events/index.ts",
+	],
 	external: ["tsup"],
-	format: ["esm"],
+	format: "esm",
 	minify: true,
 	platform: "node",
 	target: "es2022",
-	treeshake: "smallest",
 };
 
 if (env.NODE_ENV === "development") {
 	options.sourcemap = true;
 	options.minify = false;
-	(options.entry as string[]).push("src/commands/index.ts", "src/dev.ts");
+	(options.entry as string[]).push("src/dev.ts");
 }
 
 export default defineConfig(options);


### PR DESCRIPTION
**Changes this PR makes:**
In cfddadd836e0db34fc44f0d30300c879fe236cfa the possibility to bundle the commands was added with the support to fast reload in development. This wasn't done for events because using the same approach it wouldn't work (probably circular dependencies or something) so now I'm using a new approach which seems to fix this problem and gives us the possibility to easily reload the events and bundle all of them into a single file for performance reasons.