### PR TITLE
feat: add prediction reminder

### DIFF
--- a/src/commands/remind.ts
+++ b/src/commands/remind.ts
@@ -81,7 +81,8 @@ export const remindCommand = createCommand({
 				if (
 					Number.isNaN(date) ||
 					date <= Date.now() + 1_000 ||
-					date > 10_000_000_000_000
+					// 100 years
+					date > 3_153_600_000_000
 				) {
 					await interaction.reply({
 						ephemeral: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,11 @@ import { config } from "dotenv";
 import express from "express";
 import mongoose from "mongoose";
 import { join } from "node:path";
-import process, { cwd, env, memoryUsage } from "node:process";
-import { setInterval } from "node:timers/promises";
+import process, { cwd, env } from "node:process";
 import Constants, {
 	CustomClient,
 	loadPredictions,
+	logMemoryUsage,
 	printToStderr,
 	printToStdout,
 } from "./util";
@@ -62,19 +62,4 @@ for (const font in fonts)
 		);
 await mongoose.connect(env["MONGODB_URL"]!);
 await client.login();
-await loadPredictions(client);
-for await (const _ of setInterval(
-	60_000 * (env.NODE_ENV === "production" ? 10 : 1),
-)) {
-	const memory = memoryUsage();
-
-	printToStdout(
-		`RSS: ${(memory.rss / 1000 / 1000).toFixed(3)}MB\nHeap Used: ${(
-			memory.heapUsed /
-			1000 /
-			1000
-		).toFixed(3)}MB\nHeap Total: ${(memory.heapTotal / 1000 / 1000).toFixed(
-			3,
-		)}MB\nExternal: ${(memory.external / 1000 / 1000).toFixed(3)}MB`,
-	);
-}
+await Promise.all([loadPredictions(client), logMemoryUsage()]);

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -9,12 +9,14 @@ export type UserSchema = {
 		teams: string;
 	}[];
 	dayPoints?: number;
+	predictionReminder?: number;
 };
 
 export const userSchema = new Schema<UserSchema>({
 	_id: string,
 	predictions: [{ prediction: string, teams: string }],
 	dayPoints: Number,
+	predictionReminder: Number,
 });
 
 export const User = createModel("User", userSchema);

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -18,6 +18,7 @@ export * from "./loadMatchDay";
 export * from "./loadMatches";
 export * from "./loadPredictions";
 export * from "./loadQuotes";
+export * from "./logMemoryUsage";
 export * from "./logger";
 export * from "./normalizeError";
 export * from "./normalizeTeamName";

--- a/src/util/logMemoryUsage.ts
+++ b/src/util/logMemoryUsage.ts
@@ -1,0 +1,23 @@
+import { env, memoryUsage } from "node:process";
+import { setInterval } from "node:timers/promises";
+import { printToStdout } from "./logger";
+
+export const logMemoryUsage = async () => {
+	for await (const _ of setInterval(
+		60_000 * (env.NODE_ENV === "production" ? 10 : 1),
+	)) {
+		const memory = memoryUsage();
+
+		printToStdout(
+			`RSS: ${(memory.rss / 1000 / 1000).toFixed(3)}MB\nHeap Used: ${(
+				memory.heapUsed /
+				1000 /
+				1000
+			).toFixed(3)}MB\nHeap Total: ${(memory.heapTotal / 1000 / 1000).toFixed(
+				3,
+			)}MB\nExternal: ${(memory.external / 1000 / 1000).toFixed(3)}MB`,
+		);
+	}
+};
+
+export default logMemoryUsage;


### PR DESCRIPTION
**Changes this PR makes:**
Add a `/prediction reminder` subcommand which allows the user to add a reminder to send the predictions before the start of the day.
The reminder can only be set in the windows from 7 days to 1 second before the start of the day.

**Other changes:**
Lowered the maximum duration for a standard reminder to 100 years.

**Note: This still needs to be tested**