### PR TITLE
fix: do not remind if predictions sent

### DIFF
--- a/src/commands/predictions.ts
+++ b/src/commands/predictions.ts
@@ -411,7 +411,14 @@ export const predictionsCommand = createCommand({
 			});
 			return;
 		}
-		if (part === total)
+		if (part === total) {
+			const existing = Object.values(timeoutCache).find(
+				(t) =>
+					t?.action === "predictionRemind" &&
+					t.options[0] === interaction.user.id,
+			);
+
+			if (existing) await removePermanentTimeout(existing.id);
 			await interaction.reply({
 				ephemeral: true,
 				content: "Pronostici inviati correttamente!",
@@ -425,7 +432,7 @@ export const predictionsCommand = createCommand({
 					),
 				],
 			});
-		else
+		} else
 			await interaction.reply({
 				ephemeral: true,
 				content: `Parte **${part} di ${total}** inviata correttamente! Clicca il pulsante per continuare...`,

--- a/src/util/loadMatchDay.ts
+++ b/src/util/loadMatchDay.ts
@@ -78,7 +78,7 @@ export const loadMatchDay = async (
 	date = Math.round(date / 1_000);
 	if (date - Date.now() / 1_000 > 10)
 		await channel.send({
-			content: `<@&${env.PREDICTIONS_ROLE!}>, potete ora inviare i pronostici per la prossima giornata! Per inviare i pronostici potete usare il comando \`/predictions send\` e seguire le istruzioni. Avete tempo fino a <t:${date}:F> (<t:${date}:R>)`,
+			content: `<@&${env.PREDICTIONS_ROLE!}>, potete ora inviare i pronostici per la prossima giornata! Per inviare i pronostici potete usare il comando \`/predictions send\` e seguire le istruzioni. Avete tempo fino a <t:${date}:F> (<t:${date}:R>)! Vi ricordo che potete aggiungere un promemoria valido per ogni giornata per ricordarvi di inviare i pronostici con il comando \`/predictions reminder\``,
 			allowedMentions: { roles: [env.PREDICTIONS_ROLE!] },
 		});
 	return matchDay;

--- a/src/util/loadMatchDay.ts
+++ b/src/util/loadMatchDay.ts
@@ -78,7 +78,7 @@ export const loadMatchDay = async (
 	date = Math.round(date / 1_000);
 	if (date - Date.now() / 1_000 > 10)
 		await channel.send({
-			content: `<@&${env.PREDICTIONS_ROLE!}>, potete ora inviare i pronostici per la prossima giornata! Per inviare i pronostici potete usare il comando \`/predictions send\` e seguire le istruzioni. Avete tempo fino a <t:${date}:F> (<t:${date}:R>)! Vi ricordo che potete aggiungere un promemoria valido per ogni giornata per ricordarvi di inviare i pronostici con il comando \`/predictions reminder\``,
+			content: `<@&${env.PREDICTIONS_ROLE!}>, potete ora inviare i pronostici per la prossima giornata! Per inviare i pronostici potete usare il comando \`/predictions send\` e seguire le istruzioni. Avete tempo fino a <t:${date}:F> (<t:${date}:R>)! Vi ricordo che potete aggiungere un promemoria valido per ogni giornata per ricordarvi di inviare i pronostici con il comando \`/predictions reminder\`.`,
 			allowedMentions: { roles: [env.PREDICTIONS_ROLE!] },
 		});
 	return matchDay;


### PR DESCRIPTION
**Changes this PR makes:**
The predictions reminder should not be sent if the user already sent the predictions. This PR fixes this problem by removing the timeout when the user sends the predictions.