### PR TITLE
feat: implement new points system

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -177,7 +177,6 @@ module.exports = {
 		"@typescript-eslint/prefer-ts-expect-error": "warn",
 		"@typescript-eslint/require-await": "off",
 		"@typescript-eslint/return-await": "warn",
-		"@typescript-eslint/strict-boolean-expressions": "warn",
 		"@typescript-eslint/sort-type-constituents": "warn",
 		"@typescript-eslint/switch-exhaustiveness-check": "warn",
 		"@typescript-eslint/unified-signatures": "warn",

--- a/src/commands/predictions.ts
+++ b/src/commands/predictions.ts
@@ -72,7 +72,7 @@ const showModal = async (
 	return interaction.showModal(
 		new ModalBuilder()
 			.setCustomId(`predictions-${matchDay.day}-${part}-${Number(editing)}`)
-			.setTitle(`Pronostici ${matchDay.day}° Giornata (${part}/${total})`)
+			.setTitle(`Pronostici ${matchDay.day}ª Giornata (${part}/${total})`)
 			.addComponents(
 				matchDay.matches.slice((part - 1) * 5, part * 5).map((match) => {
 					const textInput = new TextInputBuilder()
@@ -289,7 +289,7 @@ export const predictionsCommand = createCommand({
 						thumbnail: {
 							url: "https://img.legaseriea.it/vimages/64df31f4/Logo-SerieA_TIM_RGB.jpg",
 						},
-						title: `${matchDay.day}° Giornata Serie A TIM`,
+						title: `${matchDay.day}ª Giornata Serie A TIM`,
 						url: "https://legaseriea.it/it/serie-a",
 					},
 				],

--- a/src/commands/quote.ts
+++ b/src/commands/quote.ts
@@ -46,7 +46,6 @@ export const quoteCommand = createCommand({
 				env.QUOTES_CHANNEL!,
 			);
 
-			// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 			if (!channel?.isTextBased()) {
 				await interaction.reply({
 					content: "Comando non disponibile!",
@@ -95,7 +94,6 @@ export const quoteCommand = createCommand({
 				env.QUOTES_CHANNEL!,
 			);
 
-			// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 			if (!channel?.isTextBased()) {
 				await interaction.respond([]);
 				return;

--- a/src/util/loadPredictions.ts
+++ b/src/util/loadPredictions.ts
@@ -68,7 +68,6 @@ export const loadPredictions = async (client: CustomClient) => {
 		throw new TypeError("Predictions channel not set!");
 	const channel = await client.channels.fetch(env.PREDICTIONS_CHANNEL);
 
-	// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 	if (!channel?.isTextBased() || channel.isDMBased())
 		throw new TypeError("Invalid predictions channel!");
 	const matchDay =

--- a/src/util/loadQuotes.ts
+++ b/src/util/loadQuotes.ts
@@ -5,7 +5,6 @@ import { printToStderr } from "./logger";
 export const loadQuotes = async (client: CustomClient<true>) => {
 	const channel = client.channels.cache.get(env.QUOTES_CHANNEL!);
 
-	// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 	if (!channel?.isTextBased()) return;
 	await channel.messages.fetch({ limit: 100 }).catch((err) => {
 		printToStderr(err);

--- a/src/util/sendPredictions.ts
+++ b/src/util/sendPredictions.ts
@@ -36,7 +36,7 @@ export const sendPredictions = async (
 						thumbnail: {
 							url: "https://img.legaseriea.it/vimages/64df31f4/Logo-SerieA_TIM_RGB.jpg",
 						},
-						title: `${matchDay.day}° Giornata Serie A TIM`,
+						title: `${matchDay.day}ª Giornata Serie A TIM`,
 					};
 				}),
 			),


### PR DESCRIPTION
## Changes this PR makes

- **Implement new points system**: now the points given to the first user in every match day is equal to the **number of users playing / 2 rounded up** and everyone else get **one point less than the user above** them.
- **Fix double leaderboard**: the description of the leaderboard was being added to the embed of the match results instead of the predictions one at match close.
- **Fix `matchPointsHistory` not properly adding `null` values to new players**: when a new user plays the predictions for the first time, it doesn't have the array with the history of `matchPoints` for every match day in the database, so the close match day function should've created this array, filled with `null` all the days not played and then saved it to the database but it wasn't correctly handling possible empty array.
- Remove an eslint rule which anyway was being disabled in most places.
- Replace ° with ª which is more correct grammatically.