### PR TITLE
feat: implement remind and match of match

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -10,6 +10,8 @@ CREATE TABLE Users (
 	id VARCHAR(31) PRIMARY KEY,
 	dayPoints INTEGER,
 	match INTEGER,
+	remindMinutes INTEGER,
+	reminded INTEGER DEFAULT 0,
 	matchPointsHistory VARCHAR(255)
 );
 CREATE TABLE Predictions (

--- a/schema.sql
+++ b/schema.sql
@@ -9,6 +9,7 @@ CREATE TABLE MatchDays (
 CREATE TABLE Users (
 	id VARCHAR(31) PRIMARY KEY,
 	dayPoints INTEGER,
+	match INTEGER,
 	matchPointsHistory VARCHAR(255)
 );
 CREATE TABLE Predictions (

--- a/src/commands/predictions.ts
+++ b/src/commands/predictions.ts
@@ -123,7 +123,7 @@ export const predictions = new Command({
 					type: ApplicationCommandOptionType.Subcommand,
 					options: [
 						{
-							type: ApplicationCommandOptionType.String,
+							type: ApplicationCommandOptionType.Integer,
 							name: "before",
 							required: true,
 							description:

--- a/src/commands/predictions.ts
+++ b/src/commands/predictions.ts
@@ -3,6 +3,8 @@ import {
 	ButtonBuilder,
 	ModalActionRowComponentBuilder,
 	ModalBuilder,
+	SelectMenuBuilder,
+	SelectMenuOptionBuilder,
 	TextInputBuilder,
 } from "@discordjs/builders";
 import {
@@ -10,6 +12,7 @@ import {
 	ApplicationCommandOptionType,
 	ApplicationCommandType,
 	ButtonStyle,
+	ComponentType,
 	InteractionResponseType,
 	MessageFlags,
 	TextInputStyle,
@@ -211,9 +214,9 @@ export const predictions = new Command({
 									)?.prediction ?? "*Non presente*",
 							})),
 							thumbnail: {
-								url: "https://img.legaseriea.it/vimages/64df31f4/Logo-SerieA_TIM_RGB.jpg",
+								url: "https://img.legaseriea.it/vimages/6685b340/SerieA_ENILIVE_RGB.jpg",
 							},
-							title: `${matchDay.day}ª Giornata Serie A TIM`,
+							title: `${matchDay.day}ª Giornata Serie A Enilive`,
 							url: "https://legaseriea.it/it/serie-a",
 						},
 					],
@@ -385,8 +388,29 @@ VALUES (?)`,
 			reply({
 				type: InteractionResponseType.ChannelMessageWithSource,
 				data: {
-					content: "Pronostici inviati correttamente!",
+					content: `Parte **${part} di ${total}** inviata correttamente!\nSeleziona il **Match of the Match** dal menù qui sotto`,
 					components: [
+						new ActionRowBuilder<SelectMenuBuilder>()
+							.addComponents(
+								new SelectMenuBuilder()
+									.setCustomId(`predictions-match--${timestamp}`)
+									.addOptions(
+										matches.map((m) =>
+											new SelectMenuOptionBuilder()
+												.setLabel(
+													[m.home_team_name, m.away_team_name]
+														.map(normalizeTeamName)
+														.join(" - "),
+												)
+												.setValue(m.match_id.toString())
+												.setDefault(
+													m.match_id === existingPredictions[0]?.match,
+												),
+										),
+									)
+									.setPlaceholder("Seleziona il Match of the Match"),
+							)
+							.toJSON(),
 						new ActionRowBuilder<ButtonBuilder>()
 							.addComponents(
 								new ButtonBuilder()
@@ -521,7 +545,7 @@ VALUES (?)`,
 				type: InteractionResponseType.ChannelMessageWithSource,
 				data: {
 					content:
-						"Puoi inviare i pronostici solo fino a 15 minuti dall'inizio del primo match della giornata!",
+						"Puoi modificare i pronostici solo fino a 15 minuti dall'inizio del primo match della giornata!",
 					flags: MessageFlags.Ephemeral,
 				},
 			});
@@ -538,6 +562,49 @@ VALUES (?)`,
 				data: {
 					flags: MessageFlags.Ephemeral,
 					content: "Non c'è nessuna giornata disponibile al momento!",
+				},
+			});
+			return;
+		}
+		if (actionOrDay === "match") {
+			if (interaction.data.component_type !== ComponentType.StringSelect)
+				return;
+			if (!interaction.data.values.length) {
+				reply({
+					type: InteractionResponseType.ChannelMessageWithSource,
+					data: {
+						content: "Non hai selezionato alcun match!",
+						flags: MessageFlags.Ephemeral,
+					},
+				});
+				return;
+			}
+			await env.DB.prepare(
+				`UPDATE Users
+				SET match = ?1
+				WHERE id = ?2;`,
+			)
+				.bind(
+					interaction.data.values[0],
+					(interaction.member ?? interaction).user!.id,
+				)
+				.run();
+			reply({
+				type: InteractionResponseType.ChannelMessageWithSource,
+				data: {
+					content: "Pronostici inviati correttamente!",
+					flags: MessageFlags.Ephemeral,
+					components: [
+						new ActionRowBuilder<ButtonBuilder>()
+							.addComponents(
+								new ButtonBuilder()
+									.setCustomId(`predictions-${matchDay.day}-1-${timestamp}`)
+									.setEmoji({ name: "✏️" })
+									.setLabel("Modifica")
+									.setStyle(ButtonStyle.Success),
+							)
+							.toJSON(),
+					],
 				},
 			});
 			return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,14 @@
+import { ActionRowBuilder, ButtonBuilder } from "@discordjs/builders";
 import {
+	ButtonStyle,
 	InteractionResponseType,
 	InteractionType,
+	RESTPostAPICurrentUserCreateDMChannelJSONBody,
+	RESTPostAPICurrentUserCreateDMChannelResult,
+	Routes,
 } from "discord-api-types/v10";
 import * as commandsObject from "./commands";
-import type { Env } from "./util";
+import type { Env, MatchDay, User } from "./util";
 import {
 	Command,
 	JsonResponse,
@@ -44,9 +49,9 @@ const server: ExportedHandler<Env> = {
 							.get(interaction.data.name)
 							?.run(interaction, env, context);
 						info(
-							`Command ${interaction.data.name} executed by ${(
-								interaction.member ?? interaction
-							).user?.username} in ${interaction.channel.name} (${
+							`Command ${interaction.data.name} executed by ${
+								(interaction.member ?? interaction).user?.username
+							} in ${interaction.channel.name} (${
 								interaction.channel.id
 							}) - guild ${interaction.guild_id}`,
 						);
@@ -60,9 +65,9 @@ const server: ExportedHandler<Env> = {
 							context,
 						);
 						info(
-							`Component interaction ${action} executed by ${(
-								interaction.member ?? interaction
-							).user?.username} in ${interaction.channel.name} (${
+							`Component interaction ${action} executed by ${
+								(interaction.member ?? interaction).user?.username
+							} in ${interaction.channel.name} (${
 								interaction.channel.id
 							}) - guild ${interaction.guild_id}`,
 						);
@@ -83,10 +88,11 @@ const server: ExportedHandler<Env> = {
 							context,
 						);
 						info(
-							`Modal interaction ${action} executed by ${(
-								interaction.member ?? interaction
-							).user?.username} in ${interaction.channel?.name} (${interaction
-								.channel?.id}) - guild ${interaction.guild_id}`,
+							`Modal interaction ${action} executed by ${
+								(interaction.member ?? interaction).user?.username
+							} in ${interaction.channel?.name} (${
+								interaction.channel?.id
+							}) - guild ${interaction.guild_id}`,
 						);
 						break;
 					default:
@@ -103,6 +109,48 @@ const server: ExportedHandler<Env> = {
 			return new JsonResponse({ error: "Method Not Allowed" }, { status: 405 });
 		}
 		return new JsonResponse({ error: "Not Found" }, { status: 404 });
+	},
+	scheduled: async ({}, env) => {
+		const { results } = await env.DB.prepare(
+			`SELECT u.id, m.day, m.startDate
+			FROM Users u
+			JOIN MatchDays m ON u.matchDayId = m.id
+			WHERE u.reminded = 0
+			  AND u.remindMinutes >= (strftime('%s', m.startDate) - strftime('%s', 'now', '+15 minutes')) / 60
+			  AND m.startDate > datetime('now', '+15 minutes')
+			  AND m.day = (SELECT MAX(day) FROM MatchDays);`,
+		).all<Pick<MatchDay, "day" | "startDate"> & Pick<User, "id">>();
+
+		console.log(results);
+		await Promise.all(
+			results.map(async ({ id: recipient_id, day, startDate }) => {
+				const { id } = (await rest.post(Routes.userChannels(), {
+					body: {
+						recipient_id,
+					} satisfies RESTPostAPICurrentUserCreateDMChannelJSONBody,
+				})) as RESTPostAPICurrentUserCreateDMChannelResult;
+
+				await rest.post(Routes.channelMessages(id), {
+					body: {
+						content:
+							"⚽ È l'ora di inviare i pronostici per la prossima giornata!",
+						components: [
+							new ActionRowBuilder<ButtonBuilder>()
+								.addComponents(
+									new ButtonBuilder()
+										.setCustomId(
+											`predictions-${day}-1-${new Date(startDate).getTime() - 1_000 * 60 * 15}`,
+										)
+										.setEmoji({ name: "⚽" })
+										.setLabel("Invia pronostici")
+										.setStyle(ButtonStyle.Primary),
+								)
+								.toJSON(),
+						],
+					},
+				});
+			}),
+		);
 	},
 };
 

--- a/src/util/closeMatchDay.ts
+++ b/src/util/closeMatchDay.ts
@@ -10,7 +10,8 @@ export const closeMatchDay = async (
 SET dayPoints = COALESCE(dayPoints, 0) + ?1,
 	matchPointsHistory = COALESCE(matchPointsHistory, "${",".repeat(
 		day - 2,
-	)}") || ?2
+	)}") || ?2,
+	reminded = 0
 WHERE id = ?3`);
 
 	return env.DB.batch([

--- a/src/util/getLiveEmbed.ts
+++ b/src/util/getLiveEmbed.ts
@@ -206,7 +206,7 @@ const resolveStats = (users: User[]) => {
 		}
 	}
 	return {
-		name: "Statistiche Serie A 2023/2024",
+		name: "Statistiche Serie A 2024/2025",
 		value: `- Punteggio più alto: ${
 			highestPoints.users.size
 				? `${[...highestPoints.users].map((id) => `<@${id}>`).join(", ")} • **${
@@ -258,7 +258,7 @@ export const getLiveEmbed = (
 ) => [
 	new EmbedBuilder()
 		.setThumbnail(
-			"https://img.legaseriea.it/vimages/64df31f4/Logo-SerieA_TIM_RGB.jpg",
+			"https://img.legaseriea.it/vimages/6685b340/SerieA_ENILIVE_RGB.jpg",
 		)
 		.setTitle(
 			finished
@@ -267,14 +267,14 @@ export const getLiveEmbed = (
 		)
 		.setDescription(resolveMatches(matches))
 		.setAuthor({
-			name: "Serie A TIM",
+			name: "Serie A Enilive",
 			url: "https://legaseriea.it/it/serie-a",
 		})
 		.setColor(0xed4245)
 		.toJSON(),
 	new EmbedBuilder()
 		.setThumbnail(
-			"https://img.legaseriea.it/vimages/64df31f4/Logo-SerieA_TIM_RGB.jpg",
+			"https://img.legaseriea.it/vimages/6685b340/SerieA_ENILIVE_RGB.jpg",
 		)
 		.setTitle(
 			finished
@@ -293,7 +293,7 @@ export const getLiveEmbed = (
 			resolveStats(users),
 		)
 		.setAuthor({
-			name: "Serie A TIM",
+			name: "Serie A Enilive",
 			url: "https://legaseriea.it/it/serie-a",
 		})
 		.setColor(0x3498db)

--- a/src/util/getMatchDayData.ts
+++ b/src/util/getMatchDayData.ts
@@ -1,4 +1,4 @@
-import { Env, MatchDay, Prediction, loadMatches } from ".";
+import { Env, MatchDay, Prediction, loadMatches, type User } from ".";
 
 export const getMatchDayData = async (
 	env: Env,
@@ -17,14 +17,15 @@ WHERE day = ${day ?? "(SELECT MAX(day) FROM MatchDays)"}`,
 	if (!matches.length) return [];
 	const { results: existingPredictions } = await env.DB.prepare(
 		`SELECT Predictions.matchId,
-	Predictions.prediction
+	Predictions.prediction,
+	Users.match
 FROM Predictions
 	JOIN Users ON Predictions.userId = Users.id
 WHERE Users.id = ?
 	AND Predictions.matchId IN (${Array(matches.length).fill("?").join(", ")})`,
 	)
 		.bind(userId, ...matches.map((m) => m.match_id))
-		.all<Pick<Prediction, "matchId" | "prediction">>();
+		.all<Pick<Prediction, "matchId" | "prediction"> & Pick<User, "match">>();
 
 	matches.sort((a, b) =>
 		new Date(a.date_time) > new Date(b.date_time) ? 1 : -1,

--- a/src/util/resolveLeaderboard.ts
+++ b/src/util/resolveLeaderboard.ts
@@ -37,6 +37,7 @@ export const resolveLeaderboard = (
 					let diffPoints = 0;
 					const toBePlayed =
 						match.match_status === 0 || match.match_status === 3;
+					const isStarred = match.match_id === user.match;
 
 					if (!toBePlayed)
 						if (type === result)
@@ -49,6 +50,7 @@ export const resolveLeaderboard = (
 							else diffPoints = 2;
 						else if (type.includes(result)) diffPoints = 1;
 						else if (type.length === 2) diffPoints = -1;
+					if (isStarred) diffPoints *= 2;
 					if (match.match_status === 2) maxPoints += diffPoints;
 					else if (home != null)
 						if (
@@ -56,15 +58,15 @@ export const resolveLeaderboard = (
 							(match.home_goal <= Number(home) &&
 								match.away_goal <= Number(away))
 						)
-							maxPoints += 3;
-						else maxPoints += 2;
-					else if (type.length === 1) maxPoints += 2;
-					else maxPoints++;
+							maxPoints += isStarred ? 6 : 3;
+						else maxPoints += isStarred ? 4 : 2;
+					else if (type.length === 1) maxPoints += isStarred ? 4 : 2;
+					else maxPoints += isStarred ? 2 : 1;
 					return toBePlayed ? points : points + diffPoints;
 				}, 0),
 				0,
 				maxPoints,
-			];
+			] as const;
 		})
 		.sort((a, b) => b[1] - a[1]);
 	const first = Math.ceil(leaderboard.length / 2);

--- a/src/util/startPredictions.ts
+++ b/src/util/startPredictions.ts
@@ -63,14 +63,15 @@ export const startPredictions = async (
 								.map(normalizeTeamName)
 								.join(" - "),
 							value:
-								data.predictions.find(
+								(data.match === match.match_id ? "⭐ " : "") +
+								(data.predictions.find(
 									(predict) => predict.matchId === match.match_id,
-								)?.prediction ?? "*Non presente*",
+								)?.prediction ?? "*Non presente*"),
 						})),
 						thumbnail: {
-							url: "https://img.legaseriea.it/vimages/64df31f4/Logo-SerieA_TIM_RGB.jpg",
+							url: "https://img.legaseriea.it/vimages/6685b340/SerieA_ENILIVE_RGB.jpg",
 						},
-						title: `${day}ª Giornata Serie A TIM`,
+						title: `${day}ª Giornata Serie A Enilive`,
 					};
 				}),
 			).then((embeds) =>

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -222,6 +222,7 @@ export type User = {
 	id: string;
 	dayPoints?: number | null;
 	matchPointsHistory?: string | null;
+	match?: number | null;
 };
 
 export type EnvVars = {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -16,3 +16,6 @@ database_id = "8a298455-ac11-4e0c-b160-4db807cf3572"
 
 [vars]
 SEASON_ID = "264681"
+
+[triggers]
+crons = ["* * * * *"]


### PR DESCRIPTION
**Changes this PR makes:**
- Implement Match of the Match following the rules decided on Discord
- Re-add `reminder` command to be notified x minutes before the match day starts
- Add 3 new columns to Users schema: 
  - `match`: the chosen Match of the Match id, 
  - `remindMinutes`: the minutes before the day starts when the reminder should be sent
  - `reminded`: whether the reminded was sent