### PR TITLE
feat: install private commands user side

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -2,6 +2,7 @@ import { env } from "cloudflare:workers";
 import {
 	ApplicationCommandOptionType,
 	ApplicationCommandType,
+	ApplicationIntegrationType,
 	ComponentType,
 	MessageFlags,
 	MessageReferenceType,
@@ -33,6 +34,7 @@ export class Dev extends Command {
 		description: "Developer commands",
 		type: ApplicationCommandType.ChatInput,
 		default_member_permissions: "0",
+		integration_types: [ApplicationIntegrationType.UserInstall],
 		options: [
 			{
 				name: "test",
@@ -366,12 +368,12 @@ export class Dev extends Command {
 						env.TEST_GUILD,
 					),
 					{
-						body: commands
-							.filter((c) => isDev || c.private)
-							.flatMap((file) => [
+						body: (isDev ?
+							commands.flatMap((file) => [
 								...(file.chatInputData ? [file.chatInputData] : []),
 								...(file.contextMenuData ?? []),
-							]) satisfies AsConst<RESTPutAPIApplicationGuildCommandsJSONBody>,
+							])
+						:	[]) satisfies AsConst<RESTPutAPIApplicationGuildCommandsJSONBody>,
 					},
 				) as Promise<APIApplicationCommand[]>
 			).catch(normalizeError),
@@ -379,18 +381,24 @@ export class Dev extends Command {
 				[]
 			:	(
 					rest.put(Routes.applicationCommands(env.DISCORD_APPLICATION_ID), {
-						body: commands
-							.filter((c) => !c.private)
-							.flatMap((file) => [
-								...(file.chatInputData ? [file.chatInputData] : []),
-								...(file.contextMenuData ?? []),
-							]) satisfies AsConst<RESTPutAPIApplicationCommandsJSONBody>,
+						body: commands.flatMap((file) => [
+							...(file.chatInputData ? [file.chatInputData] : []),
+							...(file.contextMenuData ?? []),
+						]) satisfies AsConst<RESTPutAPIApplicationCommandsJSONBody>,
 					}) as Promise<APIApplicationCommand[]>
 				).catch(normalizeError),
 		]);
 
 		await edit({
-			content: `Private commands: \`${privateAPICommands instanceof Error ? privateAPICommands.message : privateAPICommands.map((c) => c.name).join(", ")}\`\nPublic commands: \`${publicAPICommands instanceof Error ? publicAPICommands.message : publicAPICommands.map((c) => c.name).join(", ")}\``,
+			content: `Private commands: \`${
+				privateAPICommands instanceof Error ?
+					privateAPICommands.message
+				:	privateAPICommands.map((c) => c.name).join(", ") || "nessuno"
+			}\`\nPublic commands: \`${
+				publicAPICommands instanceof Error ?
+					publicAPICommands.message
+				:	publicAPICommands.map((c) => c.name).join(", ") || "nessuno"
+			}\``,
 		});
 	};
 	static "send" = async (

--- a/src/util/CommandHandler.ts
+++ b/src/util/CommandHandler.ts
@@ -132,7 +132,7 @@ export class CommandHandler {
 			} (${interaction.channel?.id})`,
 		);
 		if (!Command) return new Response(null, { status: 400 });
-		if (Command.private && !env.OWNER_ID.includes(user.id))
+		if (Command.private && env.OWNER_ID !== user.id)
 			return new Response(null, { status: 403 });
 		const { promise, resolve } =
 			Promise.withResolvers<APIInteractionResponse>();


### PR DESCRIPTION
**Changes this PR makes:**
Install private commands globally and force them to be used only for user installs.
Since the bot is private only the owner has the commands installed globally but the check in the command handler was not removed for security reasons.
In dev mode private commands are still installed locally (guild only) in order to be updated sooner